### PR TITLE
Change Zettle parser to use API key

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ clientid
 access.json
 access_2.json
 api_cred.json
+credentials/
 
 response.json
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,23 @@ You need to choose which source to retrieve the data from using `-s` or `--sourc
 
 ### Zettle 
 
+#### Set up credentials
+
+To use the Zettle API you need an API key
+
+[Click this link to create a key](https://my.zettle.com/apps/api-keys?scopes=READ:PURCHASE)
+
+The client id and key should be put in the file `main/credentials/access.json` (create the credentials folder if it doesn't exist) and should look like this:
+```json
+{
+    "grant_type": "urn:ietf:params:oauth:grant-type:jwt-bearer",
+    "client_id": "<CLIENT_ID>",
+    "assertion": "<API KEY>"
+}
+```
+
+#### Use the program
+
 The available option for the Zettle parser is:
 - `-sd` / `--start-date`
 - `-ed` / `--end-date`

--- a/main/parsers/zettle_parser.py
+++ b/main/parsers/zettle_parser.py
@@ -1,6 +1,7 @@
 # Use to generate the JSON-object from the Zettle API respnose.
 import json
 import os
+import sys
 import time
 from datetime import datetime, timedelta
 
@@ -49,6 +50,7 @@ class ZettleParser:  # Parser
             print(
                 f"error, could not get auth token. http response: {token_response.status_code} {token_response.reason}"
             )
+            sys.exit(1)
 
     def set_auth_token(self):
         saved_token_file_path = (


### PR DESCRIPTION
This changes the Zettle parser to use an API key instead of OAuth login through a web browser.
Uses [authorisation assertion grant](https://developer.zettle.com/docs/api/oauth/user-guides/set-up-app-authorisation/set-up-authorisation-assertion-grant).
See instructions in README on how to set up the credentials.