### PR TITLE
Escape `&` in tex_compiler

### DIFF
--- a/main/tex_compiler/tex_compiler.py
+++ b/main/tex_compiler/tex_compiler.py
@@ -57,7 +57,7 @@ class TexCompiler:
         acc_map = {}
 
         for _, sale in sales.items():
-            name = sale["name"]
+            name = sale["name"].replace("&", "\\&")
             quantity = sale["quantity"]
             account = sale["account"]
             unit_price = sale["unit_price"]


### PR DESCRIPTION
The table would be wrongly formatted if a name contains an `&` beacuse it is used as a column separator in latex, so we have to escape it.