### PR TITLE
Use pathlib for file reading

### DIFF
--- a/main/helpers/asset_loader.py
+++ b/main/helpers/asset_loader.py
@@ -10,7 +10,6 @@ class AssetLoader:
     def _read_file(self, fp):
         with open(fp, "r") as f:
             content = json.load(f)
-        f.close()
         return content
 
     def load_assets(self):

--- a/main/main.py
+++ b/main/main.py
@@ -149,7 +149,6 @@ def main():
     outfile = "response.json"
     with open(outfile, "w") as f:
         json.dump(parsed_data, f, indent=2)
-        f.close()
 
     tc = TexCompiler(
         outfile,

--- a/main/parsers/zettle_parser.py
+++ b/main/parsers/zettle_parser.py
@@ -216,7 +216,6 @@ class ZettleParser:  # Parser
                         f.write(str(purchase))
                         f.write("\n")
                         f.write("-----------------------\n\n")
-                        f.close()
                     short_utskott = "sk"
 
                 if short_utskott == "sk":

--- a/main/tex_compiler/tex_compiler.py
+++ b/main/tex_compiler/tex_compiler.py
@@ -38,7 +38,6 @@ class TexCompiler:
     ):
         with open(sales_fp, "r") as f:
             self.sales = json.load(f)
-            f.close()
 
         self.intakt_type = intakt_type
         _skeleton_file_name = "zettleavgift.tex" if zettle_fee_mode else "intakt.tex"
@@ -103,14 +102,13 @@ class TexCompiler:
 
     def _prepend_commands(self):
         cmds = str(self.tex_commands)
-        with open(self.intakt_skeleton, "r") as skel_f:
-            tex_skeleton = skel_f.read()
+        tex_skeleton = self.intakt_skeleton.read_text()
+
         with open(self.tex_file, "w") as temp_f:
             temp_f.seek(0)
             temp_f.write(cmds)
             temp_f.write(tex_skeleton)
             temp_f.truncate()
-            temp_f.close()
 
     def compile_all(self) -> None:
         for utskott, date_sales in self.sales.items():


### PR DESCRIPTION
As mentioned in #24, we could use pathlib's own read file function. 

I have looked at the places where we read file contents to see where we could replace with the method mentioned above. This resulted in only one replacement due to many of the file reading methods reads `.json` files.

There is one place in `swish_parser.py` where we might be able to another replacement, but I do not have any swish-files for testing so I left it as it is. 

This PR closes #24.